### PR TITLE
Update lab5.v by Ed

### DIFF
--- a/lab_05/src/11_group_ripple_carry_adder/lab5.v
+++ b/lab_05/src/11_group_ripple_carry_adder/lab5.v
@@ -51,7 +51,7 @@ module lab5
     //adder
     group_ripple_carry_adder
     #(
-        .GROUP_COUNT(GROUP_COUNT),
+        .BLOCK_COUNT(GROUP_COUNT),
         .WIDTH      (GROUP_WIDTH)
     )
     i_RCA


### PR DESCRIPTION
You must replace .GROUP_COUNT with .BLOCK_COUNT in 54 line, then everything will work. If you try to compile what is suggested in group_ripple_carry_adder and call in the lab5 module, then lab5 crashes because it does not know what GROUP_COUNT is in group_ripple_carry_adder, because there is BLOCK_COUNT.